### PR TITLE
Remove Authorization Header when sending upstream

### DIFF
--- a/ldap_auth_proxy.go
+++ b/ldap_auth_proxy.go
@@ -181,6 +181,8 @@ func (p *LDAPAuthProxy) Proxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	//Remove Authorization header when forwarding upstream
+	r.Header.Del("Authorization")
 	p.serveMux.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
The way it currently is the Authorization header is forwarded, this exposes the credentials to the backend.
Other issue is when using Kibana upstream the requests will be denied.